### PR TITLE
Remote Trace Server

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -23,6 +23,11 @@ use rfsm::remote_tracer::run_trace_server;
 #[cfg(feature = "TraceServer")]
 use rfsm::remote_tracer::TRACE_SERVER_ARGUMENT_OPTION;
 
+#[cfg(feature = "TraceServer")]
+use rfsm::remote_tracer::run_trace_server;
+#[cfg(feature = "TraceServer")]
+use rfsm::remote_tracer::TRACE_SERVER_ARGUMENT_OPTION;
+
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
     init_logging();

--- a/src/fsm_executor.rs
+++ b/src/fsm_executor.rs
@@ -22,6 +22,8 @@ use crate::basic_http_event_io_processor::BasicHTTPEventIOProcessor;
 use crate::datamodel::DATAMODEL_OPTION_PREFIX;
 use crate::event_io_processor::EventIOProcessor;
 use crate::fsm;
+#[cfg(not(feature = "xml"))]
+use crate::fsm::Fsm;
 use crate::fsm::{Event, FinishMode, InvokeId, ParamPair, ScxmlSession, SessionId};
 use crate::scxml_event_io_processor::ScxmlEventIOProcessor;
 #[cfg(feature = "xml")]


### PR DESCRIPTION
Remote Trace Server for Monitoring & Debug of FSM-Execution.

Implements the Trace-trait for a TCP-Server that communicate with a Client.
